### PR TITLE
IN-1782 - Upgrade Livy dependency versions to match Nosto environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,11 @@
 
   <properties>
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>3.2.1</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.5</spark.scala-2.12.version>
-    <spark.version>${spark.scala-2.11.version}</spark.version>
+    <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
+    <spark.version>${spark.scala-2.12.version}</spark.version>
     <hive.version>3.0.0</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
@@ -93,7 +93,7 @@
     <jetty.version>9.3.24.v20180605</jetty.version>
     <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
     <json4s.spark-2.12.version>3.5.3</json4s.spark-2.12.version>
-    <json4s.version>${json4s.spark-2.11.version}</json4s.version>
+    <json4s.version>${json4s.spark-2.12.version}</json4s.version>
     <junit.version>4.11</junit.version>
     <libthrift.version>0.9.3</libthrift.version>
     <kryo.version>4.0.2</kryo.version>
@@ -101,16 +101,16 @@
     <mockito.version>1.10.19</mockito.version>
     <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
     <netty.spark-2.12.version>4.1.17.Final</netty.spark-2.12.version>
-    <netty.version>${netty.spark-2.11.version}</netty.version>
+    <netty.version>${netty.spark-2.12.version}</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
     <scala-2.11.version>2.11.12</scala-2.11.version>
     <scala-2.12.version>2.12.10</scala-2.12.version>
-    <scala.binary.version>2.11</scala.binary.version>
-    <scala.version>${scala-2.11.version}</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <scala.version>${scala-2.12.version}</scala.version>
     <scalatest.version>3.0.8</scalatest.version>
     <scalatra.version>2.6.5</scalatra.version>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <test.redirectToFile>true</test.redirectToFile>
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
@@ -1062,19 +1062,19 @@
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
         <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
-        <spark.version>${spark.scala-2.11.version}</spark.version>
+        <spark.version>${spark.scala-2.12.version}</spark.version>
         <netty.spark-2.12.version>4.1.47.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.47.Final</netty.spark-2.11.version>
-        <netty.version>${netty.spark-2.11.version}</netty.version>
-        <java.version>1.8</java.version>
+        <netty.version>${netty.spark-2.12.version}</netty.version>
+        <java.version>11</java.version>
         <py4j.version>0.10.9</py4j.version>
         <json4s.spark-2.11.version>3.5.3</json4s.spark-2.11.version>
         <json4s.spark-2.12.version>3.6.6</json4s.spark-2.12.version>
-        <json4s.version>${json4s.spark-2.11.version}</json4s.version>
+        <json4s.version>${json4s.spark-2.12.version}</json4s.version>
         <spark.bin.download.url>
-          https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
+          https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop3.2.tgz
         </spark.bin.download.url>
-        <spark.bin.name>spark-3.0.0-bin-hadoop2.7</spark.bin.name>
+        <spark.bin.name>spark-3.0.0-bin-hadoop3.2</spark.bin.name>
       </properties>
     </profile>
 

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -46,7 +46,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-            <executable>python</executable>
+            <executable>python3</executable>
               <arguments>
                 <argument>setup.py</argument>
                 <argument>sdist</argument>
@@ -60,7 +60,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>python</executable>
+              <executable>python3</executable>
               <skip>${skipTests}</skip>
               <arguments>
                 <argument>setup.py</argument>


### PR DESCRIPTION
Updated Livy to use …
- Java 11
- Scala 2.12
- Hadoop 3.2.1
- Spark 3.0
- Python 3

Livy http://livy.incubator.apache.org/ is a REST Service for Apache Spark. It is used by Sparkmagic https://github.com/jupyter-incubator/sparkmagic to run Spark jobs from Jupyter.

- Jira: https://nostosolutions.atlassian.net/browse/IN-1782
- Forking instructions:
  - https://docs.github.com/en/get-started/quickstart/fork-a-repo
  - https://jarv.is/notes/how-to-pull-request-fork-github/
  - Note! When creating PR in github remember to choose own fork as target instead of root project
- Instructions to update Livy for Scala 2.12 https://stackoverflow.com/questions/67085984/how-to-rebuild-apache-livy-with-scala-2-12
- Livy build instructions https://github.com/apache/incubator-livy
- Building customized Livy package
```
mvn clean package -B -V -e \
    -Pspark-3.0 \
    -Pthriftserver \
    -DskipTests \
    -DskipITs \
    -Dmaven.javadoc.skip=true
```
- Configure Livy to connect Spark running in different modes https://docs.datafabric.hpe.com/62/Livy/Configure_Livy_Spark_Modes.html
- Start Spark - https://spark.apache.org/docs/latest/spark-standalone.html
  - ./sbin/start-master.sh
  -  ./sbin/start-slave.sh spark://Jaris-MacBook-Pro-2.local:7077
  - ./sbin/start-history-server.sh
  - ./bin/spark-shell --master spark://Jaris-MacBook-Pro-2.local:7077
- Identify in which mode Spark is running
  - val sc: SparkContext = ???; sc.isLocal
  - http://localhost:18080/history/app-20211221135356-0003/environment/
    - spark.master
    - spark.submit.deployMode
